### PR TITLE
Add chat member update support

### DIFF
--- a/examples/test_chat_member.py
+++ b/examples/test_chat_member.py
@@ -1,0 +1,33 @@
+import pytest
+from aiogram import Bot, Dispatcher
+from aiogram.types import ChatMemberUpdated, ChatMemberLeft
+
+from aiogram_mock.facade_factory import private_chat_tg_control
+from aiogram_mock.tg_control import PrivateChatTgControl
+
+
+async def on_member(update: ChatMemberUpdated):
+    on_member.data = update
+
+
+def create_bot_and_dispatcher():
+    bot = Bot(token='123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11')
+    dispatcher = Dispatcher()
+    dispatcher.chat_member.register(on_member)
+    return bot, dispatcher
+
+
+@pytest.fixture()
+def tg_control() -> PrivateChatTgControl:
+    bot, dispatcher = create_bot_and_dispatcher()
+    with private_chat_tg_control(bot=bot, dispatcher=dispatcher) as tg:
+        yield tg
+
+
+async def test_member_update(tg_control: PrivateChatTgControl):
+    new_member = ChatMemberLeft(user=tg_control.user)
+    await tg_control.update_member(new_member)
+    assert isinstance(tg_control.member, ChatMemberLeft)
+    result = await tg_control.bot.get_chat_member(tg_control.chat.id, tg_control.user.id)
+    assert isinstance(result, ChatMemberLeft)
+    assert isinstance(on_member.data.new_chat_member, ChatMemberLeft)

--- a/src/aiogram_mock/facade_factory.py
+++ b/src/aiogram_mock/facade_factory.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from aiogram import Bot, Dispatcher
 from aiogram.client.session.base import BaseSession
-from aiogram.types import Chat, User
+from aiogram.types import Chat, User, ChatMemberMember
 
 from aiogram_mock.mocked_session import MockedSession
 from aiogram_mock.tg_control import PrivateChatTgControl, TgControl
@@ -45,6 +45,8 @@ def private_chat_tg_control(
     )
 
     tg_state = tg_state_factory([chat])
+    tg_state.set_chat_member(chat.id, ChatMemberMember(user=target_user))
+    tg_state.set_chat_member(chat.id, ChatMemberMember(user=bot_user))
     session = mocked_session_factory(tg_state, bot_user)
     with patch.object(bot, 'session', session):
         yield PrivateChatTgControl(

--- a/src/aiogram_mock/mocked_session.py
+++ b/src/aiogram_mock/mocked_session.py
@@ -8,13 +8,20 @@ from aiogram.methods import (
     EditMessageCaption,
     EditMessageReplyMarkup,
     EditMessageText,
+    GetChatMember,
     SendMessage,
     SendPhoto,
     SetChatMenuButton,
     TelegramMethod,
 )
 from aiogram.methods.base import TelegramType
-from aiogram.types import InlineKeyboardMarkup, Message, ReplyKeyboardRemove, User
+from aiogram.types import (
+    InlineKeyboardMarkup,
+    Message,
+    ReplyKeyboardRemove,
+    User,
+    ChatMemberUnion,
+)
 from aiogram.types.base import UNSET
 
 from aiogram_mock.tg_state import TgState
@@ -99,6 +106,14 @@ class MockedSession(BaseSession):
     ) -> bool:
         return True
 
+    async def _mock_get_chat_member(
+        self,
+        bot: Bot,
+        method: GetChatMember,
+        timeout: Optional[int] = UNSET,
+    ) -> ChatMemberUnion:
+        return self._tg_state.get_chat_member(int(method.chat_id), int(method.user_id))
+
     async def _mock_edit_message_text(
         self,
         bot: Bot,
@@ -161,6 +176,7 @@ class MockedSession(BaseSession):
         EditMessageText: _mock_edit_message_text.__name__,
         EditMessageCaption: _mock_edit_message_caption.__name__,
         EditMessageReplyMarkup: _mock_edit_message_reply_markup.__name__,
+        GetChatMember: _mock_get_chat_member.__name__,
     }
 
     async def make_request(

--- a/src/aiogram_mock/tg_state.py
+++ b/src/aiogram_mock/tg_state.py
@@ -1,12 +1,24 @@
 import itertools
 from collections import defaultdict
 from dataclasses import dataclass, replace
-from typing import DefaultDict, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import (
+    DefaultDict,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 from uuid import uuid4
 
 from aiogram.methods import AnswerCallbackQuery
 from aiogram.types import (
     Chat,
+    ChatMemberMember,
+    ChatMemberUnion,
     Document,
     ForceReply,
     InlineKeyboardMarkup,
@@ -32,6 +44,8 @@ class TgState:
         self._last_callback_query_id: int = 0
         self._answers: Dict[str, AnswerCallbackQuery] = {}
 
+        self._members: Dict[int, Dict[int, ChatMemberUnion]] = {chat.id: {} for chat in chats}
+
         self._chat_user_state: Dict[int, UserState] = {chat.id: UserState() for chat in chats}
         self._selective_user_state: Dict[int, Dict[int, UserState]] = {}
 
@@ -53,6 +67,7 @@ class TgState:
         self._chats[chat.id] = chat
         self._histories[chat.id] = list(history)
         self._chat_user_state[chat.id] = UserState()
+        self._members[chat.id] = {}
 
     def next_message_id(self, chat_id: int) -> int:
         return len(self._histories[chat_id])
@@ -103,6 +118,12 @@ class TgState:
 
     def get_answer_callback_query(self, callback_query_id: str) -> AnswerCallbackQuery:
         return self._answers[callback_query_id]
+
+    def set_chat_member(self, chat_id: int, member: ChatMemberUnion) -> None:
+        self._members[chat_id][member.user.id] = member
+
+    def get_chat_member(self, chat_id: int, user_id: int) -> ChatMemberUnion:
+        return self._members[chat_id][user_id]
 
     def get_user_state(self, *, chat_id: int, user_id: int) -> UserState:
         try:


### PR DESCRIPTION
## Summary
- manage chat member state in TgState and provide access
- support GetChatMember in MockedSession
- expose chat member helpers in TgControl and PrivateChatTgControl
- initialize default members in `private_chat_tg_control`
- test chat member updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853cb4e66d48320812f9539bf4fe659