### PR TITLE
fix: utcnow deprecation warnings

### DIFF
--- a/src/aiogram_mock/mocked_session.py
+++ b/src/aiogram_mock/mocked_session.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Any, AsyncGenerator, Dict, List, Mapping, Optional, Sequence, Type, Union
 
 from aiogram import Bot
@@ -59,7 +59,7 @@ class MockedSession(BaseSession):
                 message_id=self._tg_state.next_message_id(chat_id),
                 text=method.text,
                 chat=self._tg_state.chats[chat_id],
-                date=datetime.utcnow(),
+                date=datetime.now(UTC),
                 message_thread_id=method.message_thread_id,
                 from_user=self._bot_user,
                 reply_to_message=self._process_reply(chat_id, method),
@@ -74,7 +74,7 @@ class MockedSession(BaseSession):
                 message_id=self._tg_state.next_message_id(chat_id),
                 caption=method.caption,
                 chat=self._tg_state.chats[chat_id],
-                date=datetime.utcnow(),
+                date=datetime.now(UTC),
                 message_thread_id=method.message_thread_id,
                 from_user=self._bot_user,
                 reply_to_message=self._process_reply(chat_id, method),

--- a/src/aiogram_mock/mocked_session.py
+++ b/src/aiogram_mock/mocked_session.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict, List, Mapping, Optional, Sequence, Type, Union
 
 from aiogram import Bot
@@ -59,7 +59,7 @@ class MockedSession(BaseSession):
                 message_id=self._tg_state.next_message_id(chat_id),
                 text=method.text,
                 chat=self._tg_state.chats[chat_id],
-                date=datetime.now(UTC),
+                date=datetime.now(timezone.utc),
                 message_thread_id=method.message_thread_id,
                 from_user=self._bot_user,
                 reply_to_message=self._process_reply(chat_id, method),
@@ -74,7 +74,7 @@ class MockedSession(BaseSession):
                 message_id=self._tg_state.next_message_id(chat_id),
                 caption=method.caption,
                 chat=self._tg_state.chats[chat_id],
-                date=datetime.now(UTC),
+                date=datetime.now(timezone.utc),
                 message_thread_id=method.message_thread_id,
                 from_user=self._bot_user,
                 reply_to_message=self._process_reply(chat_id, method),

--- a/src/aiogram_mock/tg_control.py
+++ b/src/aiogram_mock/tg_control.py
@@ -1,5 +1,5 @@
 import itertools
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Callable, Optional, Sequence, Union
 
 from aiogram import Bot, Dispatcher
@@ -57,7 +57,7 @@ class TgControl:
         await self._send_message(
             Message(
                 message_id=self._tg_state.next_message_id(chat.id),
-                date=datetime.utcnow(),
+                date=datetime.now(UTC),
                 from_user=from_user,
                 chat=chat,
                 text=text,
@@ -68,7 +68,7 @@ class TgControl:
         await self._send_message(
             Message(
                 message_id=self._tg_state.next_message_id(chat.id),
-                date=datetime.utcnow(),
+                date=datetime.now(UTC),
                 from_user=from_user,
                 chat=chat,
                 contact=contact,
@@ -125,7 +125,7 @@ class TgControl:
         update = ChatMemberUpdated(
             chat=chat,
             from_user=from_user,
-            date=datetime.utcnow(),
+            date=datetime.now(UTC),
             old_chat_member=old_member,
             new_chat_member=new_member,
         )

--- a/src/aiogram_mock/tg_control.py
+++ b/src/aiogram_mock/tg_control.py
@@ -1,5 +1,5 @@
 import itertools
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from typing import Callable, Optional, Sequence, Union
 
 from aiogram import Bot, Dispatcher
@@ -57,7 +57,7 @@ class TgControl:
         await self._send_message(
             Message(
                 message_id=self._tg_state.next_message_id(chat.id),
-                date=datetime.now(UTC),
+                date=datetime.now(timezone.utc),
                 from_user=from_user,
                 chat=chat,
                 text=text,
@@ -68,7 +68,7 @@ class TgControl:
         await self._send_message(
             Message(
                 message_id=self._tg_state.next_message_id(chat.id),
-                date=datetime.now(UTC),
+                date=datetime.now(timezone.utc),
                 from_user=from_user,
                 chat=chat,
                 contact=contact,
@@ -125,7 +125,7 @@ class TgControl:
         update = ChatMemberUpdated(
             chat=chat,
             from_user=from_user,
-            date=datetime.now(UTC),
+            date=datetime.now(timezone.utc),
             old_chat_member=old_member,
             new_chat_member=new_member,
         )


### PR DESCRIPTION
Fixed: 
```python
aiogram_mock/tg_control.py DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC
  ```